### PR TITLE
Feature/profile details

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "pure": "~0.6.0",
     "jquery": "~2.1.4",
-    "lodash": "~3.9.3"
+    "lodash": "~3.9.3",
+    "octicons": "~2.4.1"
   }
 }

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -191,6 +191,13 @@ textarea {
   color: #6894CD
 }
 
+.user-deets span {
+  margin-right: 4px;
+  width: 1.1em;
+  text-align: center;
+  color: #767676;
+}
+
 
 
 

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -97,8 +97,8 @@ textarea {
 
 .tabs {
   display: block;
-  font-style: sans-serif;
-  font-weight: bold;
+  font-style: Arial sans-serif;
+  font-weight: 600;
   font-size: 1.75ex;
   color: #6894CD;
   border-bottom: .2ex solid lightgray;
@@ -138,7 +138,57 @@ textarea {
   color: black;
   border-top: .35ex solid #D66729;
   border-bottom: .2ex solid white;
-  margin-bottom: -.1ex
+  margin-bottom: -.1ex;
+}
+
+.profile-details {
+  border-bottom: .2ex solid lightgray;
+}
+
+.profile-details div {
+  display: inline-block;
+  height: 8.25em;
+  vertical-align: top;
+  padding-top: 1em;
+  padding-bottom: 1em;
+}
+
+.profile-details .profile-image {
+  box-sizing: border-box;
+  width: 8.5em;
+  padding-left: 1em;
+}
+
+.profile-details .profile-image img {
+  border-radius: 3.5%;
+}
+
+.profile-details div .user-deets {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+  font-size: 1.5ex;
+}
+
+.profile-details li {
+  line-height: 3.25ex;
+}
+
+.user-deets .display-name {
+  font-size: 2.5ex;
+  font-weight: bold;
+  line-height: 2.5ex;
+}
+
+.user-deets .username {
+  color: #767676;
+  font-weight: 500;
+  padding-bottom: 1ex;
+}
+
+.user-deets li a {
+  text-decoration: none;
+  color: #6894CD
 }
 
 

--- a/src/index.html
+++ b/src/index.html
@@ -18,6 +18,21 @@
          --><li class="tabs-mobile second"><a href="#repositories"><span>Repositories</span></a></li>
           </ul>
         </nav> <!-- .tabs -->
+        <section class="profile-details">
+          <div class="profile-image">
+            <img src="https://avatars3.githubusercontent.com/u/583231?v=3&s=400" width="110px" height="110px">
+          </div>
+          <div class="profile-info">
+            <ul class="user-deets">
+              <li class="display-name">The Octocat</li>
+              <li class="username">octocat</li>
+              <li>GitHub</li>
+              <li>San Francisco</li>
+              <li><a href="octocat@github.com">octocat@github.com</a></li>
+              <li><a href="https://www.github.com/blog">https://www.github.com/blog</li>
+            </ul> <!-- .user-deets -->
+          </div>
+        </section> <!-- .profile-details -->
       </main> <!-- .container -->
       <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
       <script>window.jQuery || document.write('<script src="js/vendor/jquery-1.11.2.min.js"><\/script>')</script>

--- a/src/index.html
+++ b/src/index.html
@@ -8,6 +8,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="css/normalize.css">
         <link rel="stylesheet" href="css/main.css">
+        <link rel="stylesheet" href="../bower_components/octicons/octicons/octicons.css">
         <script src="js/vendor/modernizr-2.8.3.min.js"></script>
     </head>
     <body>
@@ -26,10 +27,10 @@
             <ul class="user-deets">
               <li class="display-name">The Octocat</li>
               <li class="username">octocat</li>
-              <li>GitHub</li>
-              <li>San Francisco</li>
-              <li><a href="octocat@github.com">octocat@github.com</a></li>
-              <li><a href="https://www.github.com/blog">https://www.github.com/blog</li>
+              <li><span class="octicon octicon-organization"></span>GitHub</li>
+              <li><span class="octicon octicon-location"></span>San Francisco</li>
+              <li><span class="octicon octicon-mail"></span><a href="octocat@github.com">octocat@github.com</a></li>
+              <li><span class="octicon octicon-link"></span><a href="https://www.github.com/blog">https://www.github.com/blog</li>
             </ul> <!-- .user-deets -->
           </div>
         </section> <!-- .profile-details -->


### PR DESCRIPTION
* [x] Creating social detail section of the github for mobile viewport
  * [x] Create container for entire social detail section (`display: block`)
  * [x] Within container create 2 `<div>`s that will be set to `display: inline-block`; set width as percentage of parent element for responsive change to viewport
    * [x] First `<div>` includes octocat image; reference implementation has image size set to 110 x 110
    * [x] Second `<div>` to include 6 additional block level elements (use `<div>`s or `<li>`s)
      * [x] Each block level element includes content of varying font sizes, sans-serif font
      * [x] Suggestion for bottom four elements with icons: hardwire the icon into html and include `<span>` tag for the content to the right of the icon (allows for padding and spacing between content and the icon
      * [x] `href` links in bottom 2 elements, `text-decoration: none` to remove the underline on the link
