### PR TITLE
added popular repositories section

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -247,6 +247,74 @@ textarea {
   color: #767676;
 }
 
+.repositories-list {
+  padding-top: 1.75ex;
+  background-color: #FAFAFA;
+  border-bottom: .2ex solid lightgray;
+}
+
+.repositories-list ul {
+  list-style-type: none;
+  width: 97.5%;
+  margin-top: 0;
+  margin-left: 1.25%;
+  margin-right: 0;
+  margin-bottom: 0;
+  padding: 0;
+  text-align: left;
+}
+
+.repositories-list ul li {
+  height: 3.1em;
+  border-right: .2ex solid lightgray;
+  border-bottom: .2ex solid #EEEEEE;
+  border-left: .2ex solid lightgray;
+  line-height: 3.1em;
+  font-size: 1.7ex;
+  font-weight: bold;
+  color: #767676;
+}
+
+.repositories-list ul li a {
+  text-decoration: none;
+  color: #3C7ABB;
+  font-weight: bold;
+}
+
+.repositories-list ul .list-header {
+  border-top: .2ex solid lightgray;
+  border-bottom: .2ex solid lightgray;
+  font-weight: bold;
+  font-size: 1.65ex;
+  padding-left: 1.25%;
+  height: 2.5em;
+  line-height: 2.5em;
+  color: #444444;
+}
+
+.repositories-list .left {
+  display: inline-block;
+  width: 49.5%;
+}
+
+.repositories-list ul .left span {
+  color: #767676;
+  padding-right: 1ex;
+  padding-left: 1.75ex;
+}
+
+
+.repositories-list .right {
+  display: inline-block;
+  text-align: right;
+  font-size: 1.5ex;
+  width: 49.5%;
+}
+
+.repositories-list ul .right span {
+  padding-right: .75ex;
+  padding-left: .4ex;
+}
 
 
 

--- a/src/index.html
+++ b/src/index.html
@@ -54,7 +54,51 @@
               </li>
             </ul> <!-- .social numbers -->
           </div> <!-- .social-numbers -->
-        </section>
+        </section> <!-- .social-stats -->
+        <section class="repositories-list">
+          <ul>
+            <li class="list-header">Popular repositories</li>
+            <li>
+              <div class="left">
+                <span class="octicon octicon-repo"></span><a href="https://www.github.com/octocat/Spoon-Knife">octocat/Spoon-Knife</a>
+              </div>
+              <div class="right">
+                9,772<span class="octicon octicon-star"></span>
+              </div>
+            </li>
+            <li>
+              <div class="left">
+                <span class="octicon octicon-repo"></span><a href="https://www.github.com/octocat/Hello-World">octocat/Hello-World</a>
+              </div>
+              <div class="right">
+                1,404<span class="octicon octicon-star"></span>
+              </div>
+            </li>
+            <li>
+              <div class="left">
+                <span class="octicon octicon-repo"></span><a href="https://www.github.com/octocat/hello-world">octocat/hello-world</a>
+              </div>
+              <div class="right">
+                10<span class="octicon octicon-star"></span>
+              </div>
+            </li>
+            <li>
+              <div class="left">
+                <span class="octicon octicon-repo"></span><a href="https://www.github.com/octocat/octocat.github.io">octocat/octocat.github.io</a>
+              </div>
+              <div class="right">
+                8<span class="octicon octicon-star"></span>
+              </div>
+            </li>
+            <li>
+              <div class="left">
+                <span class="octicon octicon-repo"></span><a href="https://www.github.com/octocat/git-consortium">octocat/git-consortium</a>
+              </div>
+              <div class="right">
+                5<span class="octicon octicon-star"></span>
+              </div>
+            </li>
+        </section> <!-- .popular-repositories -->
       </main> <!-- .container -->
       <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
       <script>window.jQuery || document.write('<script src="js/vendor/jquery-1.11.2.min.js"><\/script>')</script>


### PR DESCRIPTION
* [x] Create 'Popular repositories' section of octocat profile
  * [x] Create large container `<div>` for entire section
  * [x] Within the container include a `<ul>` tag and the appropriate 6 `<li>` tags (`display: block`) for the content within the section (style `<li>` tags with `list-style-type: none` to remove any bullet points, include light gray border on all 4 sides of each `<li>`)
  * [x] First `<li>` includes Popular repositories text, `<strong>` in sans-serif font
  * [x] Bottom 5 `<li>`s include an `<a href=''>` tag, `<span>` tag, `::before` pseudoelement, and `::after` pseudoelement
  * [x] Within `<a href=''>` tag include repo name, style with `text-decoration: none` to remove underline and include `color: blue` if necessary
  * [x] Within `<span>` tag, include the star number, and style as darkgray, sans-serif font
  * [x] Include icon (see reference implementation) in `::before` pseudoelement and `::after` pseudoelement (icon is dark gray)